### PR TITLE
Fix for Powershell profile command parsing issue

### DIFF
--- a/NVMQuickSwitch/Functions/NodeFunctions.cs
+++ b/NVMQuickSwitch/Functions/NodeFunctions.cs
@@ -29,7 +29,7 @@ namespace NVMQuickSwitch.Functions
         {
             var process = new Process()
             {
-                StartInfo = new ProcessStartInfo("powershell", command)
+                StartInfo = new ProcessStartInfo("powershell", $"-NoProfile {command}")
                 {
                     UseShellExecute = false,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
This stops the profile loading when running NVM commands, so the app works correctly even with weird setups like mine.